### PR TITLE
bugfix: fixed file path joining in `update_settings_from_file()`

### DIFF
--- a/scripts/sd-TemporalKit-UI.py
+++ b/scripts/sd-TemporalKit-UI.py
@@ -329,7 +329,7 @@ def update_settings_from_file(folderpath):
     border = None
     print (f"batch settings exists = {os.path.exists(read_path)}")
     if os.path.exists(read_path) == False:
-        read_path = os.path.join(folderpath,"0/batch_settings.txt")
+        read_path = os.path.join(folderpath,"0","batch_settings.txt")
         video_path = os.path.join(folderpath,"main_video.mp4")
         transition_data_path = os.path.join(folderpath,"transition_data.txt")
         if os.path.exists(transition_data_path):


### PR DESCRIPTION
## Summary

This PR addresses a file path joining issue in Windows. The existing code was not handling file paths correctly due to the use of / as a path separator, which is problematic on Windows, where \ is used instead. This could result in errors when trying to access files.

The code has been updated to use os.path.join for creating file paths, allowing the correct file separator to be used for the current operating system.

This change will ensure that the script works as expected across different operating systems, increasing its portability.

## changes

* `0/batch_settings.txt` -> `os.path.join(folderpath,"0","batch_settings.txt")`


## output log

```py
Traceback (most recent call last):
  File "C:\Users\<your-name>\workspace\ai\stable-diffusion-webui\venv\lib\site-packages\gradio\routes.py", line 414, in run_predict
    output = await app.get_blocks().process_api(
  File "C:\Users\<your-name>\workspace\ai\stable-diffusion-webui\venv\lib\site-packages\gradio\blocks.py", line 1323, in process_api
    result = await self.call_function(
  File "C:\Users\<your-name>\workspace\ai\stable-diffusion-webui\venv\lib\site-packages\gradio\blocks.py", line 1051, in call_function
    prediction = await anyio.to_thread.run_sync(
  File "C:\Users\<your-name>\workspace\ai\stable-diffusion-webui\venv\lib\site-packages\anyio\to_thread.py", line 31, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "C:\Users\<your-name>\workspace\ai\stable-diffusion-webui\venv\lib\site-packages\anyio\_backends\_asyncio.py", line 937, in run_sync_in_worker_thread
    return await future
  File "C:\Users\<your-name>\workspace\ai\stable-diffusion-webui\venv\lib\site-packages\anyio\_backends\_asyncio.py", line 867, in run
    result = context.run(func, *args)
  File "C:\Users\<your-name>\workspace\ai\stable-diffusion-webui\extensions\TemporalKit\scripts\sd-TemporalKit-UI.py", line 340, in update_settings_from_file
    with open(read_path, "r") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\<your-name>\\workspace\\movie\\base2-mini\\input\\0/batch_settings.txt'
```