### PR TITLE
Update sd-TemporalKit-UI.py

### DIFF
--- a/scripts/sd-TemporalKit-UI.py
+++ b/scripts/sd-TemporalKit-UI.py
@@ -403,7 +403,7 @@ def create_video_Processing_Tab():
             with gr.Tabs(elemn_id="TemporalKit_gallery_container"):
                 with gr.TabItem(elem_id="output_TemporalKit", label="Output"):
                     with gr.Row():
-                        result_image = gr.outputs.Image(type='pil')
+                        result_image = gr.components.Image(type='pil')
                     with gr.Row():
                         runbutton = gr.Button("Run") 
                     with gr.Row():

--- a/scripts/sd-TemporalKit-UI.py
+++ b/scripts/sd-TemporalKit-UI.py
@@ -20,7 +20,7 @@ import stat
 import gradio as gr
 import modules.extras
 from modules.ui_components import FormRow, FormGroup, ToolButton, FormHTML
-from modules.ui import create_toprow, create_sampler_and_steps_selection
+from modules.ui import Toprow, create_sampler_and_steps_selection
 import json
 from modules.sd_samplers import samplers, samplers_for_img2img
 import re
@@ -240,7 +240,7 @@ def read_images_folder(folder_path):
 
 
 def numpy_array_to_data_uri(img_array):
-    # convert the array to an image using PIL
+# convert the array to an image using PIL
     img = Image.fromarray(img_array)
 
     # create a BytesIO object to hold the image data

--- a/scripts/sd-TemporalKit-UI.py
+++ b/scripts/sd-TemporalKit-UI.py
@@ -240,7 +240,7 @@ def read_images_folder(folder_path):
 
 
 def numpy_array_to_data_uri(img_array):
-# convert the array to an image using PIL
+    # convert the array to an image using PIL
     img = Image.fromarray(img_array)
 
     # create a BytesIO object to hold the image data


### PR DESCRIPTION
Hello, After update Stable Diffusion [1.6.0](https://github.com/AUTOMATIC1111/stable-diffusion-webui/releases/tag/v1.6.0).
I fixed this error https://github.com/CiaraStrawberry/TemporalKit/issues/82#issue-1837794243

And I fixed this error
```bat
WARNING:py.warnings:E:\Stable-Diffusion\extensions\TemporalKit\scripts\sd-TemporalKit-UI.py:406: 
GradioDeprecationWarning: Usage of gradio.outputs is deprecated, and will not be supported in the future,
please import your components from gradio.components
  result_image = gr.outputs.Image(type='pil')
```