### PR TITLE
Fix tab not showing up in A111 v1.6.0+

### DIFF
--- a/scripts/sd-TemporalKit-UI.py
+++ b/scripts/sd-TemporalKit-UI.py
@@ -20,7 +20,7 @@ import stat
 import gradio as gr
 import modules.extras
 from modules.ui_components import FormRow, FormGroup, ToolButton, FormHTML
-from modules.ui import create_toprow, create_sampler_and_steps_selection
+from modules.ui import  create_sampler_and_steps_selection
 import json
 from modules.sd_samplers import samplers, samplers_for_img2img
 import re


### PR DESCRIPTION
Credit for this fix: https://github.com/CiaraStrawberry/TemporalKit/issues/97#issuecomment-1704467578
This should fix #82, #92, #93, #95, #97 and probably more.
The simple change was the A111 developer changed `create_toprow` to `Toprow`. As this script doesn't use either, it's safe to remove the unused Import. This fixes the error.

For those looking to fix this themselves:
1. Open `extensions\TemporalKit\scripts\sd-TemporalKit-UI.py` with a text editor.
2. Replace the following line:
```
from modules.ui import create_toprow, create_sampler_and_steps_selection
```
with
```
from modules.ui import create_sampler_and_steps_selection 
```
3. Save the file, and restart A111. The tab should now appear.